### PR TITLE
TEN-3521: tenon-cli does not honor API request parameters

### DIFF
--- a/bin/tenon-cli.js
+++ b/bin/tenon-cli.js
@@ -80,7 +80,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
     docId: 'docID',
     fragment: 'fragment',
     projectId: 'projectID',
-    userAgent: 'UAString',
+    userAgent: 'uaString',
     viewPortHeight: 'viewPortHeight',
     viewPortWidth: 'viewPortWidth'
   };
@@ -137,7 +137,8 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
   // Initialize the Tenon API object
   var tenonApi = new _tenonNode2.default({
     key: allOptions.key,
-    endPoint: allOptions.endpoint });
+    endPoint: allOptions.endpoint // or your private tenon instance
+  });
 
   var writeResultFile = function writeResultFile(result, file) {
     try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tenon-cli",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A CLI for the Node wrapper of the Tenon.io API.",
   "engines": {
     "node": ">=4"

--- a/tenon-cli.js
+++ b/tenon-cli.js
@@ -68,7 +68,7 @@ getStdin().then(pipedHTML => {
     docId: 'docID',
     fragment: 'fragment',
     projectId: 'projectID',
-    userAgent: 'UAString',
+    userAgent: 'uaString',
     viewPortHeight: 'viewPortHeight',
     viewPortWidth: 'viewPortWidth',
   };


### PR DESCRIPTION
This PR ensures that the `userAgent` CLI argument gets properly mapped to the API's `uaString` argument.